### PR TITLE
Correction of battery level

### DIFF
--- a/battery/js/base.js
+++ b/battery/js/base.js
@@ -11,7 +11,7 @@
     if (battery) {
         function setStatus () {
             console.log("Set status");
-            batteryLevel.innerHTML = parseInt(battery.level, 10) * 100 + "%";
+            batteryLevel.innerHTML = Math.round(battery.level * 100) + "%";
             chargingStatus.innerHTML = (battery.charging)? "" : "not ";
             batteryCharged.innerHTML = (battery.chargingTime == "Infinity")? "Infinity" : parseInt(battery.chargingTime / 60, 10);
             batteryDischarged.innerHTML = (battery.dischargingTime == "Infinity")? "Infinity" : parseInt(battery.dischargingTime / 60, 10);


### PR DESCRIPTION
parseInt on a number between 0 and 1 (values of battery.level) returns
0 or 1. This shows 0% or 100% and not the intermediate values.

I removed the parseInt as it isn't necessary and added Math.round for
not geting the whole float value after the multiplication by 100.
