### PR TITLE
Small fix for matchMedia demo

### DIFF
--- a/matchmedia/js/base.js
+++ b/matchmedia/js/base.js
@@ -22,7 +22,7 @@
     }
 
     function setWidthValue (mediaQueryList) {
-        width600.innerHTML = mediaQueryList.media;
+        width600.innerHTML = mediaQueryList.matches;
     }
 
     function setHeightValue (mediaQueryList) {


### PR DESCRIPTION
Hi,

This fixes a small problem with min-width event listener in the matchMedia demo.  When the window was resized down, the value for "window.matchMedia for 600 pixels width" would change from "true" to "(min-width: 600px)".

On a separate note, you seem to have some files with CRLF or mixed LF and CRLF line endings in your repo.  This confuses the heck out of my Windows client making it think these files have been modified locally even though they haven't.  You may want to consider normalizing these to all LF in the repo if possible.

The list of files that were giving me trouble are:
./html5/js/shHTMLJavaScript.js
./html5/syntax-highlighter/scripts/shBrushBash.js
./html5/syntax-highlighter/scripts/shBrushCSharp.js
./html5/syntax-highlighter/scripts/shBrushCpp.js
./html5/syntax-highlighter/scripts/shBrushCss.js
./html5/syntax-highlighter/scripts/shBrushDelphi.js
./html5/syntax-highlighter/scripts/shBrushDiff.js
./html5/syntax-highlighter/scripts/shBrushGroovy.js
./html5/syntax-highlighter/scripts/shBrushJScript.js
./html5/syntax-highlighter/scripts/shBrushJava.js
./html5/syntax-highlighter/scripts/shBrushPerl.js
./html5/syntax-highlighter/scripts/shBrushPhp.js
./html5/syntax-highlighter/scripts/shBrushPlain.js
./html5/syntax-highlighter/scripts/shBrushPython.js
./html5/syntax-highlighter/scripts/shBrushRuby.js
./html5/syntax-highlighter/scripts/shBrushScala.js
./html5/syntax-highlighter/scripts/shBrushSql.js
./html5/syntax-highlighter/scripts/shBrushVb.js
./html5/syntax-highlighter/scripts/shBrushXml.js
./html5/syntax-highlighter/scripts/shCore.js
./html5/syntax-highlighter/scripts/shHTML.js
./html5/syntax-highlighter/scripts/shHTMLJavaScript.js
./html5/syntax-highlighter/scripts/shJavaScript.js
./html5/syntax-highlighter/scripts/shLegacy.js
