### PR TITLE
Changed check for fullscreen state to reflect latest spec

### DIFF
--- a/fullscreen/js/base.js
+++ b/fullscreen/js/base.js
@@ -34,7 +34,7 @@
     var fullscreenState = document.getElementById("fullscreen-state");
     if (fullscreenState) {
         document.addEventListener("fullscreenchange", function () {
-            fullscreenState.innerHTML = (document.fullscreen)? "" : "not ";
+            fullscreenState.innerHTML = (document.fullscreenElement)? "" : "not ";
         }, false);
         
         document.addEventListener("mozfullscreenchange", function () {


### PR DESCRIPTION
document.fullscreenElement seems to be the right attribute to check state:
http://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#api
