### PR TITLE
navigator.mozBattery -> .battery

### DIFF
--- a/battery/js/base.js
+++ b/battery/js/base.js
@@ -1,5 +1,5 @@
 (function () {
-    var battery = navigator.mozBattery, 
+    var battery = navigator.battery, 
         batterySupported = document.getElementById("battery-supported"),
         batteryLevel = document.getElementById("battery-level"),
         chargingStatus = document.getElementById("charging-status"),


### PR DESCRIPTION
Given that this is sort of an official demo for the battery API (it's linked from your article at Mozilla Hacks), I think this change is justified so the demo actually works.
