### PR TITLE
Update base.js to fix race condition

### DIFF
--- a/html5demos/indexeddb/js/base.js
+++ b/html5demos/indexeddb/js/base.js
@@ -64,7 +64,9 @@
                 imgElephant.setAttribute("src", imgURL);
 
                 // Revoking ObjectURL
-                URL.revokeObjectURL(imgURL);
+                imgElephant.onload = function() {
+                    window.URL.revokeObjectURL(this.src);
+                }
             };
         };
 


### PR DESCRIPTION
In Chrome, the ObjectUrl was being revoked before the image fully loaded.  If you wrap that revoke into an onload handler for the image, it solves that problem.